### PR TITLE
Fix AWS IMDS discovery of ipv6 and ipv4 addresses

### DIFF
--- a/pkg/volumes/aws/volumes.go
+++ b/pkg/volumes/aws/volumes.go
@@ -118,17 +118,14 @@ func NewAWSVolumes(clusterName string, volumeTags []string, nameTag string) (*AW
 		o.Region = region
 	})
 	ipv6Resp, err := a.imds.GetMetadata(ctx, &imds.GetMetadataInput{Path: "ipv6"})
-	if err != nil {
-		return nil, fmt.Errorf("error querying ec2 metadata service (for ipv6): %v", err)
-	}
-	ipv6, err := io.ReadAll(ipv6Resp.Content)
-	if err != nil {
-		return nil, fmt.Errorf("error reading ec2 metadata service response (for ipv6): %v", err)
-	}
-	a.localIP = string(ipv6)
-
 	// If we have an IPv6 address, return
 	if err == nil {
+		ipv6, err := io.ReadAll(ipv6Resp.Content)
+		if err != nil {
+			return nil, fmt.Errorf("error reading ec2 metadata service response (for ipv6): %v", err)
+		}
+		a.localIP = string(ipv6)
+
 		return a, nil
 	}
 	var awsErr *awshttp.ResponseError


### PR DESCRIPTION
Testing in https://github.com/kubernetes/kops/pull/16722 revealed we were returning an error when ipv6 wasn't found, instead of falling back to ipv4

https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kops/16722/pull-kops-e2e-k8s-aws-calico/1819545673658273792/artifacts/13.52.61.91/etcd.log

`error querying ec2 metadata service (for ipv6): operation error ec2imds: GetMetadata, http response error StatusCode: 404, request to EC2 IMDS failed`

/cc @hakman