### PR TITLE
make logs related to refreshControlStore more informative

### DIFF
--- a/pkg/controller/commands.go
+++ b/pkg/controller/commands.go
@@ -35,7 +35,7 @@ func (m *EtcdController) refreshControlStore(ttl time.Duration) error {
 
 	now := time.Now()
 	if ttl != time.Duration(0) && now.Before(m.controlLastRead.Add(ttl)) {
-		klog.V(4).Infof("not refreshing commands - TTL not hit")
+		klog.V(4).Infof("not refreshing control store - TTL not hit")
 		return nil
 	}
 	klog.Infof("refreshing commands")
@@ -43,6 +43,7 @@ func (m *EtcdController) refreshControlStore(ttl time.Duration) error {
 	if err != nil {
 		return err
 	}
+	klog.Infof("refreshing cluster spec")
 	controlClusterSpec, err := m.controlStore.GetExpectedClusterSpec()
 	if err != nil {
 		return err

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -344,7 +344,7 @@ func (m *EtcdController) run(ctx context.Context) (bool, error) {
 	}
 
 	if err := m.refreshControlStore(m.controlRefreshInterval); err != nil {
-		return false, fmt.Errorf("error refreshing commands: %v", err)
+		return false, fmt.Errorf("error refreshing control store: %v", err)
 	}
 
 	isNewCluster, err := m.controlStore.IsNewCluster()

--- a/pkg/controller/upgrade.go
+++ b/pkg/controller/upgrade.go
@@ -101,7 +101,7 @@ func (m *EtcdController) stopForUpgrade(parentContext context.Context, clusterSp
 
 		for {
 			if err := m.refreshControlStore(time.Duration(0)); err != nil {
-				return false, fmt.Errorf("error refreshing commands: %v", err)
+				return false, fmt.Errorf("error refreshing control store: %v", err)
 			}
 			if m.getRestoreBackupCommand() != nil {
 				break


### PR DESCRIPTION
The refreshControlStore() function [1] makes a call to both ListCommands() and GetExpectedClusterSpec(). It doesn't just refresh commands. Moreover, there is inconsistency in error logs for this function call. Some calls log "...refreshing control store" [2, 3] and some calls log "...refreshing commands" [4]. I'm changing the logs lines from "refreshing commands" to "refreshing control store" to address this.


[1] https://github.com/kubernetes-sigs/etcd-manager/blob/1722f205ad4b0f0f2a138e4b603ad2bea13afb0e/pkg/controller/commands.go#L32
[2] https://github.com/kubernetes-sigs/etcd-manager/blob/1722f205ad4b0f0f2a138e4b603ad2bea13afb0e/pkg/controller/controller.go#L241
[3] https://github.com/kubernetes-sigs/etcd-manager/blob/1722f205ad4b0f0f2a138e4b603ad2bea13afb0e/pkg/controller/controller.go#L358
[4] https://github.com/kubernetes-sigs/etcd-manager/blob/1722f205ad4b0f0f2a138e4b603ad2bea13afb0e/pkg/controller/controller.go#L347