### PR TITLE
Add empty disk replacement member recovery

### DIFF
--- a/pkg/apis/etcd/etcdapi.pb.go
+++ b/pkg/apis/etcd/etcdapi.pb.go
@@ -338,6 +338,7 @@ type GetInfoResponse struct {
 	ClusterName       string                 `protobuf:"bytes,2,opt,name=cluster_name,json=clusterName,proto3" json:"cluster_name,omitempty"`
 	NodeConfiguration *EtcdNode              `protobuf:"bytes,5,opt,name=node_configuration,json=nodeConfiguration,proto3" json:"node_configuration,omitempty"`
 	EtcdState         *EtcdState             `protobuf:"bytes,6,opt,name=etcd_state,json=etcdState,proto3" json:"etcd_state,omitempty"`
+	DiskEmpty         bool                   `protobuf:"varint,7,opt,name=disk_empty,json=diskEmpty,proto3" json:"disk_empty,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -391,6 +392,13 @@ func (x *GetInfoResponse) GetEtcdState() *EtcdState {
 		return x.EtcdState
 	}
 	return nil
+}
+
+func (x *GetInfoResponse) GetDiskEmpty() bool {
+	if x != nil {
+		return x.DiskEmpty
+	}
+	return false
 }
 
 type UpdateEndpointsRequest struct {
@@ -1431,12 +1439,14 @@ const file_pkg_apis_etcd_etcdapi_proto_rawDesc = "" +
 	"\x06backup\x18\x03 \x01(\tR\x06backup\"O\n" +
 	"\x17CreateNewClusterCommand\x124\n" +
 	"\fcluster_spec\x18\x01 \x01(\v2\x11.etcd.ClusterSpecR\vclusterSpec\"\x10\n" +
-	"\x0eGetInfoRequest\"\xa3\x01\n" +
+	"\x0eGetInfoRequest\"\xc2\x01\n" +
 	"\x0fGetInfoResponse\x12!\n" +
 	"\fcluster_name\x18\x02 \x01(\tR\vclusterName\x12=\n" +
 	"\x12node_configuration\x18\x05 \x01(\v2\x0e.etcd.EtcdNodeR\x11nodeConfiguration\x12.\n" +
 	"\n" +
-	"etcd_state\x18\x06 \x01(\v2\x0f.etcd.EtcdStateR\tetcdState\"H\n" +
+	"etcd_state\x18\x06 \x01(\v2\x0f.etcd.EtcdStateR\tetcdState\x12\x1d\n" +
+	"\n" +
+	"disk_empty\x18\a \x01(\bR\tdiskEmpty\"H\n" +
 	"\x16UpdateEndpointsRequest\x12.\n" +
 	"\n" +
 	"member_map\x18\x01 \x01(\v2\x0f.etcd.MemberMapR\tmemberMap\":\n" +

--- a/pkg/apis/etcd/etcdapi.proto
+++ b/pkg/apis/etcd/etcdapi.proto
@@ -74,6 +74,8 @@ message GetInfoResponse {
 
     EtcdNode node_configuration = 5;
     EtcdState etcd_state = 6;
+
+    bool disk_empty = 7;
 }
 
 message UpdateEndpointsRequest {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -501,6 +501,13 @@ func (m *EtcdController) run(ctx context.Context) (bool, error) {
 		}
 	}
 
+	{
+		changed, err := m.maybeRemoveStaleMemberForEmptyDiskReplacement(ctx, clusterSpec, clusterState, versionMismatch, quarantinedMembers)
+		if changed || err != nil {
+			return changed, err
+		}
+	}
+
 	// remove unhealthy members if we need a slot to add an idle peer
 	if len(clusterState.healthyMembers) < int(len(clusterState.members)) {
 		// We only want to remove members to make room to add another

--- a/pkg/controller/replacement.go
+++ b/pkg/controller/replacement.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/klog/v2"
+	protoetcd "sigs.k8s.io/etcd-manager/pkg/apis/etcd"
+	"sigs.k8s.io/etcd-manager/pkg/etcdclient"
+	"sigs.k8s.io/etcd-manager/pkg/privateapi"
+)
+
+type etcdMemberRef struct {
+	id     EtcdMemberId
+	member *etcdclient.EtcdProcessMember
+}
+
+type diskReplacementCandidate struct {
+	peerID   privateapi.PeerId
+	peer     *etcdClusterPeerInfo
+	memberID EtcdMemberId
+	member   *etcdclient.EtcdProcessMember
+}
+
+func (c diskReplacementCandidate) String() string {
+	return fmt.Sprintf("peer=%q memberID=%q memberName=%q", c.peerID, c.memberID, c.member.Name)
+}
+
+func (m *EtcdController) maybeRemoveStaleMemberForEmptyDiskReplacement(ctx context.Context, clusterSpec *protoetcd.ClusterSpec, clusterState *etcdClusterState, versionMismatch []*etcdClusterPeerInfo, quarantinedMembers int) (bool, error) {
+	desiredMemberCount := int(clusterSpec.MemberCount)
+	if desiredMemberCount < 3 {
+		return false, nil
+	}
+	if len(versionMismatch) != 0 {
+		return false, nil
+	}
+	if quarantinedMembers != 0 {
+		return false, nil
+	}
+	if len(clusterState.members) != desiredMemberCount {
+		return false, nil
+	}
+	if len(clusterState.healthyMembers) < quorumSize(len(clusterState.members)) {
+		klog.Infof("empty disk replacement recovery is waiting for healthy quorum: healthy=%d members=%d", len(clusterState.healthyMembers), len(clusterState.members))
+		return false, nil
+	}
+
+	candidate := m.findDiskReplacementCandidate(clusterState)
+	if candidate == nil {
+		return false, nil
+	}
+
+	if !m.diskReplacementCandidatePastDeadline(candidate, time.Now()) {
+		return false, nil
+	}
+
+	if !m.hasEtcdLeader(ctx, clusterState) {
+		klog.Infof("empty disk replacement candidate %s is waiting for an etcd leader", candidate)
+		return false, nil
+	}
+
+	if _, err := m.doClusterBackup(ctx, clusterSpec, clusterState); err != nil {
+		return false, fmt.Errorf("failed to backup before replacing member %q: %v", candidate.member.Name, err)
+	}
+
+	klog.Infof("removing stale etcd member for empty disk replacement: %s", candidate)
+	if err := clusterState.etcdRemoveMember(ctx, candidate.member); err != nil {
+		return false, fmt.Errorf("failed to remove stale member %q for empty disk replacement peer %q: %v", candidate.member, candidate.peerID, err)
+	}
+
+	return true, nil
+}
+
+func (m *EtcdController) diskReplacementCandidatePastDeadline(candidate *diskReplacementCandidate, now time.Time) bool {
+	// peerState is keyed by stringified etcd member ID cast to PeerId (see controller.go's main loop);
+	// we use the stale member ID here to look up health history for the member being replaced.
+	peerState := m.peerState[privateapi.PeerId(candidate.memberID)]
+	if peerState == nil {
+		klog.Warningf("empty disk replacement candidate %s has no health history for stale etcd member ID %q; waiting", candidate, candidate.memberID)
+		return false
+	}
+	age := now.Sub(peerState.lastEtcdHealthy)
+	if age < removeUnhealthyDeadline {
+		klog.Infof("empty disk replacement candidate %s is waiting for stale member unhealthy deadline %s (currently %s)", candidate, removeUnhealthyDeadline, age)
+		return false
+	}
+	return true
+}
+
+func (m *EtcdController) findDiskReplacementCandidate(clusterState *etcdClusterState) *diskReplacementCandidate {
+	byName := make(map[string][]etcdMemberRef)
+	for id, member := range clusterState.members {
+		if member.Name == "" {
+			continue
+		}
+		byName[member.Name] = append(byName[member.Name], etcdMemberRef{id: id, member: member})
+	}
+
+	var candidates []diskReplacementCandidate
+	for peerID, peer := range clusterState.peers {
+		if peer == nil || peer.info == nil || !peer.info.DiskEmpty {
+			continue
+		}
+		if peer.info.NodeConfiguration == nil {
+			klog.Warningf("empty disk peer %q has no node configuration; not treating it as a replacement", peerID)
+			continue
+		}
+		if peer.info.EtcdState != nil && peer.info.EtcdState.Cluster != nil {
+			klog.Warningf("empty disk peer %q already has etcd cluster state; not treating it as a replacement", peerID)
+			continue
+		}
+
+		name := peer.info.NodeConfiguration.Name
+		if name == "" {
+			klog.Warningf("empty disk peer %q has empty node name; not treating it as a replacement", peerID)
+			continue
+		}
+
+		refs := byName[name]
+		if len(refs) > 1 {
+			klog.Warningf("empty disk peer %q matches multiple etcd members named %q; skipping this candidate", peerID, name)
+			continue
+		}
+		if len(refs) == 0 {
+			continue
+		}
+		ref := refs[0]
+		if clusterState.healthyMembers[ref.id] != nil {
+			klog.Infof("empty disk peer %q matches healthy etcd member name %q; not treating it as a replacement", peerID, name)
+			continue
+		}
+
+		candidates = append(candidates, diskReplacementCandidate{
+			peerID:   peerID,
+			peer:     peer,
+			memberID: ref.id,
+			member:   ref.member,
+		})
+	}
+
+	if len(candidates) > 1 {
+		klog.Warningf("found multiple empty disk replacement candidates (%s); replacement recovery is ambiguous and will no-op", formatDiskReplacementCandidates(candidates))
+		return nil
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	return &candidates[0]
+}
+
+func formatDiskReplacementCandidates(candidates []diskReplacementCandidate) string {
+	var parts []string
+	for _, candidate := range candidates {
+		parts = append(parts, candidate.String())
+	}
+	return strings.Join(parts, ", ")
+}
+
+func (m *EtcdController) hasEtcdLeader(ctx context.Context, clusterState *etcdClusterState) bool {
+	for id, member := range clusterState.healthyMembers {
+		etcdClient, err := clusterState.newEtcdClient(member)
+		if err != nil {
+			klog.Warningf("unable to build client for healthy member %s while checking leader: %v", id, err)
+			continue
+		}
+
+		checkCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		leaderID, err := etcdClient.LeaderID(checkCtx)
+		cancel()
+		etcdclient.LoggedClose(etcdClient)
+		if err != nil {
+			klog.Warningf("unable to check leader on healthy member %s: %v", id, err)
+			continue
+		}
+		if leaderID != "" {
+			return true
+		}
+		klog.Infof("healthy member %s reported no etcd leader", id)
+	}
+
+	return false
+}

--- a/pkg/controller/replacement_test.go
+++ b/pkg/controller/replacement_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	protoetcd "sigs.k8s.io/etcd-manager/pkg/apis/etcd"
+	"sigs.k8s.io/etcd-manager/pkg/etcdclient"
+	"sigs.k8s.io/etcd-manager/pkg/privateapi"
+)
+
+func TestFindDiskReplacementCandidateMatchesUnhealthyMemberByName(t *testing.T) {
+	clusterState := newReplacementTestClusterState()
+
+	candidate := (&EtcdController{}).findDiskReplacementCandidate(clusterState)
+	if candidate == nil {
+		t.Fatalf("findDiskReplacementCandidate() returned nil")
+	}
+	if candidate.peerID != "etcd-a" {
+		t.Fatalf("candidate peerID = %q, want etcd-a", candidate.peerID)
+	}
+	if candidate.memberID != "1" {
+		t.Fatalf("candidate memberID = %q, want stale etcd member ID 1", candidate.memberID)
+	}
+}
+
+func TestFindDiskReplacementCandidateNoOpsOnMultipleCandidates(t *testing.T) {
+	clusterState := newReplacementTestClusterState()
+	clusterState.members["4"] = &etcdclient.EtcdProcessMember{
+		ID:         "4",
+		Name:       "etcd-d",
+		ClientURLs: []string{"https://127.0.0.4:4001"},
+	}
+	clusterState.peers["etcd-d"] = diskEmptyPeer("etcd-d")
+
+	candidate := (&EtcdController{}).findDiskReplacementCandidate(clusterState)
+	if candidate != nil {
+		t.Fatalf("findDiskReplacementCandidate() = %v, want nil for ambiguous candidates", candidate)
+	}
+}
+
+func TestFindDiskReplacementCandidateNoOpsWhenMatchingMemberHealthy(t *testing.T) {
+	clusterState := newReplacementTestClusterState()
+	clusterState.healthyMembers["1"] = clusterState.members["1"]
+
+	candidate := (&EtcdController{}).findDiskReplacementCandidate(clusterState)
+	if candidate != nil {
+		t.Fatalf("findDiskReplacementCandidate() = %v, want nil when matching member is healthy", candidate)
+	}
+}
+
+func TestFindDiskReplacementCandidateNoOpsWhenDiskEmptyPeerHasClusterState(t *testing.T) {
+	clusterState := newReplacementTestClusterState()
+	clusterState.peers["etcd-a"].info.EtcdState = &protoetcd.EtcdState{
+		Cluster: &protoetcd.EtcdCluster{ClusterToken: "token"},
+	}
+
+	candidate := (&EtcdController{}).findDiskReplacementCandidate(clusterState)
+	if candidate != nil {
+		t.Fatalf("findDiskReplacementCandidate() = %v, want nil when peer has cluster state", candidate)
+	}
+}
+
+func TestDiskReplacementCandidateDeadlineUsesStaleMemberID(t *testing.T) {
+	now := time.Now()
+	candidate := &diskReplacementCandidate{
+		peerID:   "etcd-a",
+		memberID: "12345",
+		member: &etcdclient.EtcdProcessMember{
+			ID:   "12345",
+			Name: "etcd-a",
+		},
+	}
+
+	controller := &EtcdController{
+		peerState: map[privateapi.PeerId]*peerState{
+			"etcd-a": {
+				lastEtcdHealthy: now.Add(-2 * removeUnhealthyDeadline),
+			},
+		},
+	}
+	if controller.diskReplacementCandidatePastDeadline(candidate, now) {
+		t.Fatalf("diskReplacementCandidatePastDeadline() used peer name health history, want stale member ID history")
+	}
+
+	controller.peerState[privateapi.PeerId(candidate.memberID)] = &peerState{
+		lastEtcdHealthy: now.Add(-2 * removeUnhealthyDeadline),
+	}
+	if !controller.diskReplacementCandidatePastDeadline(candidate, now) {
+		t.Fatalf("diskReplacementCandidatePastDeadline() = false, want true using stale member ID history")
+	}
+}
+
+func newReplacementTestClusterState() *etcdClusterState {
+	members := map[EtcdMemberId]*etcdclient.EtcdProcessMember{
+		"1": {
+			ID:         "1",
+			Name:       "etcd-a",
+			ClientURLs: []string{"https://127.0.0.1:4001"},
+		},
+		"2": {
+			ID:         "2",
+			Name:       "etcd-b",
+			ClientURLs: []string{"https://127.0.0.2:4001"},
+		},
+		"3": {
+			ID:         "3",
+			Name:       "etcd-c",
+			ClientURLs: []string{"https://127.0.0.3:4001"},
+		},
+	}
+
+	return &etcdClusterState{
+		members: members,
+		healthyMembers: map[EtcdMemberId]*etcdclient.EtcdProcessMember{
+			"2": members["2"],
+			"3": members["3"],
+		},
+		peers: map[privateapi.PeerId]*etcdClusterPeerInfo{
+			"etcd-a": diskEmptyPeer("etcd-a"),
+			"etcd-b": configuredPeer("etcd-b"),
+			"etcd-c": configuredPeer("etcd-c"),
+		},
+	}
+}
+
+func diskEmptyPeer(name string) *etcdClusterPeerInfo {
+	return &etcdClusterPeerInfo{
+		peer: &peer{Id: privateapi.PeerId(name)},
+		info: &protoetcd.GetInfoResponse{
+			DiskEmpty: true,
+			NodeConfiguration: &protoetcd.EtcdNode{
+				Name: name,
+			},
+		},
+	}
+}
+
+func configuredPeer(name string) *etcdClusterPeerInfo {
+	return &etcdClusterPeerInfo{
+		peer: &peer{Id: privateapi.PeerId(name)},
+		info: &protoetcd.GetInfoResponse{
+			NodeConfiguration: &protoetcd.EtcdNode{
+				Name: name,
+			},
+			EtcdState: &protoetcd.EtcdState{
+				Cluster: &protoetcd.EtcdCluster{ClusterToken: "token"},
+			},
+		},
+	}
+}

--- a/pkg/etcd/etcdserver.go
+++ b/pkg/etcd/etcdserver.go
@@ -213,6 +213,7 @@ func (s *EtcdServer) GetInfo(ctx context.Context, request *protoetcd.GetInfoRequ
 	response := &protoetcd.GetInfoResponse{}
 	response.ClusterName = s.clusterName
 	response.NodeConfiguration = s.etcdNodeConfiguration
+	response.DiskEmpty = isDiskEmpty(s.baseDir)
 
 	if s.state != nil && s.state.Cluster != nil {
 		response.EtcdState = s.state
@@ -230,6 +231,49 @@ func (s *EtcdServer) GetInfo(ctx context.Context, request *protoetcd.GetInfoRequ
 	//}
 
 	return response, nil
+}
+
+func isDiskEmpty(baseDir string) bool {
+	statePath := filepath.Join(baseDir, StateFileName)
+	if _, err := os.Stat(statePath); err == nil {
+		return false
+	} else if !os.IsNotExist(err) {
+		klog.Warningf("error checking state file %q: %v", statePath, err)
+		return false
+	}
+
+	for _, name := range []string{DataDirName, TrashcanDirName} {
+		p := filepath.Join(baseDir, name)
+		empty, err := isMissingOrEmptyDir(p)
+		if err != nil {
+			klog.Warningf("error checking data directory %q: %v", p, err)
+			return false
+		}
+		if !empty {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isMissingOrEmptyDir(p string) (bool, error) {
+	stat, err := os.Stat(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	if !stat.IsDir() {
+		return false, fmt.Errorf("%q exists but is not a directory", p)
+	}
+
+	entries, err := os.ReadDir(p)
+	if err != nil {
+		return false, err
+	}
+	return len(entries) == 0, nil
 }
 
 // UpdateEndpoints updates /etc/hosts with the other cluster members

--- a/pkg/etcd/etcdserver_test.go
+++ b/pkg/etcd/etcdserver_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	protoetcd "sigs.k8s.io/etcd-manager/pkg/apis/etcd"
+)
+
+func TestIsDiskEmpty(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, dir string)
+		want  bool
+	}{
+		{
+			name: "missing state data and trashcan",
+			want: true,
+		},
+		{
+			name: "empty data and trashcan dirs",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				mkdirAll(t, filepath.Join(dir, DataDirName))
+				mkdirAll(t, filepath.Join(dir, TrashcanDirName))
+			},
+			want: true,
+		},
+		{
+			name: "state exists",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				writeFile(t, filepath.Join(dir, StateFileName))
+			},
+		},
+		{
+			name: "data has entry",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				mkdirAll(t, filepath.Join(dir, DataDirName, "cluster-token"))
+			},
+		},
+		{
+			name: "trashcan has entry",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				mkdirAll(t, filepath.Join(dir, TrashcanDirName, "cluster-token"))
+			},
+		},
+		{
+			name: "data path is file",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				writeFile(t, filepath.Join(dir, DataDirName))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if test.setup != nil {
+				test.setup(t, dir)
+			}
+			if got := isDiskEmpty(dir); got != test.want {
+				t.Fatalf("isDiskEmpty() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestGetInfoReportsDiskEmptyLive(t *testing.T) {
+	dir := t.TempDir()
+	server := &EtcdServer{
+		baseDir:     dir,
+		clusterName: "test",
+		etcdNodeConfiguration: &protoetcd.EtcdNode{
+			Name: "etcd-a",
+		},
+	}
+
+	response, err := server.GetInfo(context.Background(), &protoetcd.GetInfoRequest{})
+	if err != nil {
+		t.Fatalf("GetInfo() returned error: %v", err)
+	}
+	if !response.DiskEmpty {
+		t.Fatalf("GetInfo().DiskEmpty = false, want true")
+	}
+
+	mkdirAll(t, filepath.Join(dir, DataDirName, "cluster-token"))
+
+	response, err = server.GetInfo(context.Background(), &protoetcd.GetInfoRequest{})
+	if err != nil {
+		t.Fatalf("GetInfo() returned error: %v", err)
+	}
+	if response.DiskEmpty {
+		t.Fatalf("GetInfo().DiskEmpty = true after data was created, want false")
+	}
+}
+
+func mkdirAll(t *testing.T, p string) {
+	t.Helper()
+	if err := os.MkdirAll(p, 0755); err != nil {
+		t.Fatalf("MkdirAll(%q) failed: %v", p, err)
+	}
+}
+
+func writeFile(t *testing.T, p string) {
+	t.Helper()
+	if err := os.WriteFile(p, []byte("x"), 0644); err != nil {
+		t.Fatalf("WriteFile(%q) failed: %v", p, err)
+	}
+}

--- a/test/integration/emptydisk_test.go
+++ b/test/integration/emptydisk_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"k8s.io/klog/v2"
+	protoetcd "sigs.k8s.io/etcd-manager/pkg/apis/etcd"
+	"sigs.k8s.io/etcd-manager/pkg/etcdclient"
+	"sigs.k8s.io/etcd-manager/test/integration/harness"
+)
+
+func TestEmptyDiskReplacementRecovery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	ctx := context.TODO()
+	ctx, cancel := context.WithTimeout(ctx, 6*time.Minute)
+	defer cancel()
+
+	h := harness.NewTestHarness(t, ctx)
+	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "3.5.7"})
+	defer h.Close()
+
+	n1 := h.NewNode("127.0.0.1")
+	n2 := h.NewNode("127.0.0.2")
+	n3 := h.NewNode("127.0.0.3")
+	nodes := []*harness.TestHarnessNode{n1, n2, n3}
+	for _, node := range nodes {
+		go node.Run()
+	}
+
+	members := waitForMemberCount(ctx, h, n1, 3, time.Minute)
+	waitForAllNodesHealthy(ctx, h, nodes, time.Minute)
+
+	key := "/testing/empty-disk-replacement"
+	value := time.Now().String()
+	if err := n1.Put(ctx, key, value); err != nil {
+		t.Fatalf("error writing key %q: %v", key, err)
+	}
+
+	victim := highestPeerIDNode(t, nodes)
+	victimPeerID, err := victim.PeerID()
+	if err != nil {
+		t.Fatalf("error reading victim peer id: %v", err)
+	}
+	if memberID := memberIDForName(members, string(victimPeerID)); memberID == "" {
+		t.Fatalf("could not find etcd member for victim peer %q in %v", victimPeerID, members)
+	}
+
+	klog.Infof("replacing node %s with peer id %q using an empty disk", victim.Address, victimPeerID)
+	if _, err := victim.ReplaceWithEmptyDiskSameIdentity(); err != nil {
+		t.Fatalf("failed to replace victim disk: %v", err)
+	}
+	go victim.Run()
+
+	members = waitForMemberCount(ctx, h, victim, 3, 4*time.Minute)
+	if memberID := memberIDForName(members, string(victimPeerID)); memberID == "" {
+		t.Fatalf("replacement peer %q was not present in etcd members %v", victimPeerID, members)
+	}
+
+	h.WaitFor(time.Minute, "replacement can read previously written key", func() error {
+		actual, err := victim.GetQuorum(ctx, key)
+		if err != nil {
+			return err
+		}
+		if actual != value {
+			return fmt.Errorf("unexpected value for %q: got %q, want %q", key, actual, value)
+		}
+		return nil
+	})
+}
+
+func waitForAllNodesHealthy(ctx context.Context, h *harness.TestHarness, nodes []*harness.TestHarnessNode, timeout time.Duration) {
+	h.WaitFor(timeout, "all nodes list members", func() error {
+		for _, node := range nodes {
+			if _, err := node.ListMembers(ctx); err != nil {
+				return fmt.Errorf("node %s did not list members: %w", node.Address, err)
+			}
+		}
+		return nil
+	})
+}
+
+func waitForMemberCount(ctx context.Context, h *harness.TestHarness, node *harness.TestHarnessNode, count int, timeout time.Duration) []*etcdclient.EtcdProcessMember {
+	var members []*etcdclient.EtcdProcessMember
+	h.WaitFor(timeout, fmt.Sprintf("node %s sees %d members", node.Address, count), func() error {
+		var err error
+		members, err = node.ListMembers(ctx)
+		if err != nil {
+			return err
+		}
+		if len(members) != count {
+			return fmt.Errorf("got %d members, want %d: %v", len(members), count, members)
+		}
+		return nil
+	})
+	return members
+}
+
+func highestPeerIDNode(t *testing.T, nodes []*harness.TestHarnessNode) *harness.TestHarnessNode {
+	t.Helper()
+
+	type nodeWithPeerID struct {
+		node   *harness.TestHarnessNode
+		peerID string
+	}
+
+	var withPeerIDs []nodeWithPeerID
+	for _, node := range nodes {
+		peerID, err := node.PeerID()
+		if err != nil {
+			t.Fatalf("error reading peer id for node %s: %v", node.Address, err)
+		}
+		withPeerIDs = append(withPeerIDs, nodeWithPeerID{node: node, peerID: string(peerID)})
+	}
+	sort.Slice(withPeerIDs, func(i, j int) bool {
+		return withPeerIDs[i].peerID < withPeerIDs[j].peerID
+	})
+	return withPeerIDs[len(withPeerIDs)-1].node
+}
+
+func memberIDForName(members []*etcdclient.EtcdProcessMember, name string) string {
+	for _, member := range members {
+		if member.Name == name {
+			return member.ID
+		}
+	}
+	return ""
+}

--- a/test/integration/harness/node.go
+++ b/test/integration/harness/node.go
@@ -56,6 +56,7 @@ type TestHarnessNode struct {
 	ctxCancel context.CancelFunc
 
 	ClientURL      string
+	peerServer     *privateapi.Server
 	etcdServer     *etcd.EtcdServer
 	etcdController *controller.EtcdController
 
@@ -161,6 +162,7 @@ func (n *TestHarnessNode) Run() {
 	if err != nil {
 		klog.Fatalf("error building server: %v", err)
 	}
+	n.peerServer = peerServer
 
 	scheme := "https"
 	if n.InsecureMode {
@@ -261,6 +263,10 @@ func (n *TestHarnessNode) Close() error {
 		n.ctxCancel()
 		n.ctxCancel = nil
 	}
+	if n.peerServer != nil {
+		n.peerServer.GrpcServer().Stop()
+		n.peerServer = nil
+	}
 	// Stop etcd
 	if n.etcdServer != nil {
 		_, err := n.etcdServer.StopEtcdProcessForTest()
@@ -269,6 +275,35 @@ func (n *TestHarnessNode) Close() error {
 		}
 	}
 	return nil
+}
+
+func (n *TestHarnessNode) PeerID() (privateapi.PeerId, error) {
+	return privateapi.PersistentPeerId(n.NodeDir)
+}
+
+func (n *TestHarnessNode) ReplaceWithEmptyDiskSameIdentity() (privateapi.PeerId, error) {
+	peerID, err := n.PeerID()
+	if err != nil {
+		return "", err
+	}
+
+	if err := n.Close(); err != nil {
+		return "", err
+	}
+	if err := os.RemoveAll(n.NodeDir); err != nil {
+		return "", fmt.Errorf("failed to delete node directory %q: %v", n.NodeDir, err)
+	}
+	if err := os.MkdirAll(n.NodeDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to recreate node directory %q: %v", n.NodeDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(n.NodeDir, "myid"), []byte(peerID), 0644); err != nil {
+		return "", fmt.Errorf("failed to seed peer id %q: %v", peerID, err)
+	}
+
+	n.etcdServer = nil
+	n.etcdController = nil
+	n.peerServer = nil
+	return peerID, nil
 }
 
 // AssertVersion asserts that the client reports the server version specified


### PR DESCRIPTION
```mermaid
flowchart TD
    Start([reconcile cycle]) --> Pre{"<b>Leader preconditions</b><br/>• desiredMemberCount ≥ 3<br/>• no version mismatch<br/>• no quarantined members<br/>• members == desired<br/>• healthy ≥ quorum(M)"}
    Pre -- any fail --> Skip1([skip: normal reconcile continues])
    Pre -- all pass --> Find["<b>findDiskReplacementCandidate</b><br/>peer.info.DiskEmpty == true<br/>NodeConfiguration.Name non-empty<br/>EtcdState.Cluster == nil<br/>exactly one etcd member with same Name<br/>that member NOT in healthyMembers"]

    Find --> Count{candidates}
    Count -- "0" --> Skip2([skip: nothing to do])
    Count -- "> 1" --> Skip3([skip: ambiguous, WARN])
    Count -- "1" --> Deadline{"<b>Stale member unhealthy</b><br/>≥ removeUnhealthyDeadline (1m)?<br/>source: peerState[memberID].lastEtcdHealthy"}

    Deadline -- no --> Skip4([skip: wait out the deadline])
    Deadline -- yes --> Leader{"<b>hasEtcdLeader?</b><br/>any healthy member reports<br/>a non-empty LeaderID"}

    Leader -- no --> Skip5([skip: no leader, wait])
    Leader -- yes --> Backup["<b>doClusterBackup</b><br/>safety net before mutating membership"]

    Backup --> Remove["<b>etcdRemoveMember(stale)</b><br/>frees the member slot"]
    Remove --> Return([return changed=true])

    Return -.next cycle.-> NextCycle["<b>addNodeToCluster</b> (existing path)<br/>picks the idle empty-disk peer →<br/>PHASE_PREPARE → etcdAddMember →<br/>PHASE_JOIN_EXISTING<br/>(state synced via raft snapshot)"]
    NextCycle --> Healthy([healthy M-member cluster])

    classDef skip fill:#fee,stroke:#c66
    classDef act fill:#efe,stroke:#383
    class Skip1,Skip2,Skip3,Skip4,Skip5 skip
    class Backup,Remove,NextCycle,Healthy act
```

/cc @justinsb 