### PR TITLE
Validate path inputs against traversals

### DIFF
--- a/pkg/backup/vfs.go
+++ b/pkg/backup/vfs.go
@@ -31,6 +31,20 @@ import (
 	"sigs.k8s.io/etcd-manager/pkg/apis/etcd"
 )
 
+// validateBackupName checks that a backup name is safe to use as a single path component
+func validateBackupName(name string) error {
+	if name == "" {
+		return fmt.Errorf("backup name must not be empty")
+	}
+	if name != path.Base(name) {
+		return fmt.Errorf("backup name contains invalid path characters: %q", name)
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("backup name must not be %q", name)
+	}
+	return nil
+}
+
 func NewVFSStore(p vfs.Path) (Store, error) {
 	s := &vfsStore{
 		spec:        p.Path(),
@@ -123,6 +137,9 @@ func (s *vfsStore) ListBackups() ([]string, error) {
 }
 
 func (s *vfsStore) RemoveBackup(backup string) error {
+	if err := validateBackupName(backup); err != nil {
+		return err
+	}
 	p := s.backupsBase.Join(backup)
 	ctx := context.TODO()
 	files, err := p.ReadTree(ctx)
@@ -141,6 +158,10 @@ func (s *vfsStore) RemoveBackup(backup string) error {
 }
 
 func (s *vfsStore) LoadInfo(name string) (*etcd.BackupInfo, error) {
+	if err := validateBackupName(name); err != nil {
+		return nil, err
+	}
+
 	klog.Infof("Loading info for backup %q", name)
 
 	ctx := context.TODO()
@@ -167,6 +188,10 @@ func (s *vfsStore) Spec() string {
 }
 
 func (s *vfsStore) DownloadBackup(name string, destFile string) error {
+	if err := validateBackupName(name); err != nil {
+		return err
+	}
+
 	klog.Infof("Downloading backup %q -> %s", name, destFile)
 
 	dir := path.Dir(destFile)

--- a/pkg/etcd/etcdserver.go
+++ b/pkg/etcd/etcdserver.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -39,6 +40,19 @@ import (
 )
 
 const PreparedValidity = time.Minute
+
+// validateSubDirectory checks that child is a direct subdirectory of parent
+func validateSubDirectory(parent, child string) error {
+	cleaned := filepath.Clean(child)
+	rel, err := filepath.Rel(parent, cleaned)
+	if err != nil {
+		return fmt.Errorf("path %q is not within %q: %v", child, parent, err)
+	}
+	if strings.HasPrefix(rel, "..") || rel == "." {
+		return fmt.Errorf("path %q escapes parent directory %q", child, parent)
+	}
+	return nil
+}
 
 // Names of the on-disk entries under baseDir that etcd-manager owns.
 const (
@@ -481,13 +495,20 @@ func (s *EtcdServer) StopEtcd(ctx context.Context, request *protoetcd.StopEtcdRe
 		return nil, err
 	}
 
-	oldDataDir := filepath.Join(s.baseDir, DataDirName, clusterToken)
+	dataParent := filepath.Join(s.baseDir, DataDirName)
+	oldDataDir := filepath.Join(dataParent, clusterToken)
+	if err := validateSubDirectory(dataParent, oldDataDir); err != nil {
+		return nil, fmt.Errorf("invalid ClusterToken: %v", err)
+	}
 	trashcanDir := filepath.Join(s.baseDir, TrashcanDirName)
 	if err := os.MkdirAll(trashcanDir, 0755); err != nil {
 		klog.Warningf("error creating trashcan directory %s: %v", trashcanDir, err)
 	}
 
 	newDataDir := filepath.Join(trashcanDir, clusterToken)
+	if err := validateSubDirectory(trashcanDir, newDataDir); err != nil {
+		return nil, fmt.Errorf("invalid ClusterToken: %v", err)
+	}
 	klog.Infof("archiving etcd data directory %s -> %s", oldDataDir, newDataDir)
 
 	if err := os.Rename(oldDataDir, newDataDir); err != nil {
@@ -559,7 +580,13 @@ func (s *EtcdServer) startEtcdProcess(state *protoetcd.EtcdState) error {
 		return fmt.Errorf("ClusterToken not configured, cannot start etcd")
 	}
 	dataDir := filepath.Join(s.baseDir, DataDirName, state.Cluster.ClusterToken)
+	if err := validateSubDirectory(filepath.Join(s.baseDir, DataDirName), dataDir); err != nil {
+		return fmt.Errorf("invalid ClusterToken: %v", err)
+	}
 	pkiDir := filepath.Join(s.baseDir, PkiDirName, state.Cluster.ClusterToken)
+	if err := validateSubDirectory(filepath.Join(s.baseDir, PkiDirName), pkiDir); err != nil {
+		return fmt.Errorf("invalid ClusterToken: %v", err)
+	}
 	klog.Infof("starting etcd with datadir %s", dataDir)
 
 	state = proto.Clone(state).(*protoetcd.EtcdState)


### PR DESCRIPTION
The clusterToken from cluster state is used directly in filepath.Join() without validation. The token enters via JoinClusterRequest which is remotely triggered. This PR verifies constructed paths stay within their expected parent directories.

The BackupName from restore requests is used in path construction without sanitization. This validates backup names to reject path separators and .. components.

/cc @hakman