### PR TITLE
Tighten file permissions

### DIFF
--- a/cmd/etcd-manager/main.go
+++ b/cmd/etcd-manager/main.go
@@ -384,7 +384,7 @@ func RunEtcdManager(o *EtcdManagerOptions) error {
 		klog.Infof("Setting data dir to %s", o.DataDir)
 	}
 
-	if err := os.MkdirAll(o.DataDir, 0755); err != nil {
+	if err := os.MkdirAll(o.DataDir, 0700); err != nil {
 		return fmt.Errorf("error doing mkdirs on base directory %s: %v", o.DataDir, err)
 	}
 

--- a/pkg/etcd/etcdserver.go
+++ b/pkg/etcd/etcdserver.go
@@ -141,7 +141,7 @@ func writeState(baseDir string, state *protoetcd.EtcdState) error {
 		return fmt.Errorf("error marshaling state data: %w", err)
 	}
 
-	if err := os.WriteFile(p, b, 0755); err != nil {
+	if err := os.WriteFile(p, b, 0600); err != nil {
 		return fmt.Errorf("error writing state file %q: %w", p, err)
 	}
 	return nil

--- a/pkg/locking/flock.go
+++ b/pkg/locking/flock.go
@@ -57,7 +57,7 @@ func (l *FSFlockLock) Acquire(ctx context.Context, id string) (LockGuard, error)
 	//	return nil, fmt.Errorf("error serializing lock info: %v", err)
 	//}
 
-	f, err := os.OpenFile(l.p, os.O_RDWR|os.O_CREATE, 0755)
+	f, err := os.OpenFile(l.p, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("error opening lock file %q: %v", l.p, err)
 	}

--- a/pkg/locking/fs.go
+++ b/pkg/locking/fs.go
@@ -67,7 +67,7 @@ func (l *FSContentLock) Acquire(ctx context.Context, id string) (LockGuard, erro
 	hash := sha256.Sum256(b)
 	lockBytes := []byte(hex.EncodeToString(hash[:]) + "\n" + string(b))
 
-	f, err := os.OpenFile(l.p, os.O_RDWR|os.O_CREATE, 0755)
+	f, err := os.OpenFile(l.p, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("error creating lock file %q: %v", l.p, err)
 	}
@@ -148,7 +148,7 @@ func (l *FSContentLock) Acquire(ctx context.Context, id string) (LockGuard, erro
 }
 
 func (l *FSContentLockGuard) Release() error {
-	f, errO := os.OpenFile(l.p, os.O_RDWR, 0755)
+	f, errO := os.OpenFile(l.p, os.O_RDWR, 0600)
 	if errO != nil {
 		return fmt.Errorf("error opening file %q: %v", l.p, errO)
 	}

--- a/pkg/pki/fs.go
+++ b/pkg/pki/fs.go
@@ -95,7 +95,7 @@ func (s *FSStore) Keypair(name string) MutableKeypair {
 }
 
 func writePrivateKey(path string, privateKey *rsa.PrivateKey) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return fmt.Errorf("creating directories for private key file %q: %w", path, err)
 	}
 
@@ -125,7 +125,7 @@ func (s *FSStore) WriteCABundle(ca *CA) error {
 }
 
 func writeCertificates(path string, certificates ...*x509.Certificate) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return fmt.Errorf("creating directories for certificate file %q: %w", path, err)
 	}
 

--- a/pkg/volumes/openstack/volumes.go
+++ b/pkg/volumes/openstack/volumes.go
@@ -513,7 +513,7 @@ func probeVolume() error {
 		for _, f := range dirs {
 			name := scsiPath + f.Name() + "/scan"
 			data := []byte("- - -")
-			os.WriteFile(name, data, 0666)
+			os.WriteFile(name, data, 0200)
 		}
 	}
 


### PR DESCRIPTION
This restricts the file and directory permissions to only what is required. All child processes run as the same user id as etcd-manager itself, so no other user needs to access these files.

Changes:
* State file (pkg/etcd/etcdserver.go): 0755 → 0600 — contains serialized cluster metadata, not executable
* Data directory (cmd/etcd-manager/main.go): 0755 → 0700 — etcd data should be private to owner
* PKI directories (pkg/pki/fs.go): 0755 → 0700 — parent dirs for private keys and certificates should not be world-listable
* Lock files (pkg/locking/fs.go, pkg/locking/flock.go): 0755 → 0600 — lock files are data, not executables
* sysfs scan trigger (pkg/volumes/openstack/volumes.go): 0666 → 0200 — /sys/class/scsi_host/*/scan is a write-only kernel trigger

Written with assistance from Opus 4.6

/cc @hakman