### PR TITLE
PKI Improvements

### DIFF
--- a/pkg/pki/certutils.go
+++ b/pkg/pki/certutils.go
@@ -36,9 +36,14 @@ const (
 
 	// RSAPrivateKeyBlockType is a possible value for pem.Block.Type.
 	RSAPrivateKeyBlockType = "RSA PRIVATE KEY"
-
-	rsaKeySize = 4096
 )
+
+var rsaKeySize = 4096
+
+// SetRSAKeySize overrides the RSA key size used for certificate generation, for use in testing.
+func SetRSAKeySize(size int) {
+	rsaKeySize = size
+}
 
 // newPrivateKey creates an RSA private key
 func newPrivateKey() (*rsa.PrivateKey, error) {

--- a/pkg/pki/certutils.go
+++ b/pkg/pki/certutils.go
@@ -37,7 +37,7 @@ const (
 	// RSAPrivateKeyBlockType is a possible value for pem.Block.Type.
 	RSAPrivateKeyBlockType = "RSA PRIVATE KEY"
 
-	rsaKeySize = 2048
+	rsaKeySize = 4096
 )
 
 // newPrivateKey creates an RSA private key

--- a/pkg/privateapi/peers.go
+++ b/pkg/privateapi/peers.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/etcd-manager/pkg/contextutil"
 	"sigs.k8s.io/etcd-manager/pkg/privateapi/discovery"
@@ -298,7 +299,7 @@ func (p *peer) connect() (*grpc.ClientConn, error) {
 		opts = append(opts, grpc.WithTransportCredentials(creds))
 	} else {
 		klog.Warningf("connecting to peer %q insecurely", p.id)
-		opts = append(opts, grpc.WithInsecure())
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
 	opts = append(opts, grpc.WithBackoffMaxDelay(10*time.Second))

--- a/test/integration/harness/cluster.go
+++ b/test/integration/harness/cluster.go
@@ -58,6 +58,9 @@ type TestHarness struct {
 }
 
 func NewTestHarness(t *testing.T, ctx context.Context) *TestHarness {
+	// Use smaller RSA keys in tests for faster certificate generation.
+	pki.SetRSAKeySize(2048)
+
 	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Errorf("error building tempdir: %v", err)


### PR DESCRIPTION
* Replaced deprecated [grpc.WithInsecure()](https://pkg.go.dev/google.golang.org/grpc#WithInsecure)
* Increased RSA key size from 2048 to 4096 bits

/cc @hakman