### PR TITLE
Use etcdutl to restore snapshots with etcd 3.6+

### DIFF
--- a/pkg/etcd/etcdprocess.go
+++ b/pkg/etcd/etcdprocess.go
@@ -414,7 +414,22 @@ func (p *etcdProcess) DoBackup(store backup.Store, info *protoetcd.BackupInfo) (
 	return DoBackup(store, info, p.DataDir, clientUrls, p.etcdClientTLSConfig)
 }
 
-// RestoreV3Snapshot calls etcdctl snapshot restore
+// snapshotRestoreCommand uses etcdutl for etcd 3.6+, where snapshot restore moved out of etcdctl.
+func (p *etcdProcess) snapshotRestoreCommand() string {
+	version, err := semver.ParseTolerant(p.EtcdVersion)
+	if err != nil {
+		klog.Warningf("error parsing version %q: %v", p.EtcdVersion, err)
+		return "etcdctl"
+	}
+
+	if version.Major > 3 || (version.Major == 3 && version.Minor >= 6) {
+		return "etcdutl"
+	}
+
+	return "etcdctl"
+}
+
+// RestoreV3Snapshot calls etcdctl or etcdutl snapshot restore
 func (p *etcdProcess) RestoreV3Snapshot(snapshotFile string) error {
 	me := p.findMyNode()
 	if me == nil {
@@ -426,7 +441,8 @@ func (p *etcdProcess) RestoreV3Snapshot(snapshotFile string) error {
 		initialCluster = append(initialCluster, node.Name+"="+strings.Join(node.PeerUrls, ","))
 	}
 
-	c := exec.Command(path.Join(p.BinDir, "etcdctl"))
+	restoreCommand := p.snapshotRestoreCommand()
+	c := exec.Command(path.Join(p.BinDir, restoreCommand))
 	c.Args = append(c.Args, "snapshot", "restore", snapshotFile)
 	c.Args = append(c.Args, "--name", me.Name)
 	c.Args = append(c.Args, "--initial-cluster", strings.Join(initialCluster, ","))
@@ -444,14 +460,14 @@ func (p *etcdProcess) RestoreV3Snapshot(snapshotFile string) error {
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 	if err := c.Start(); err != nil {
-		return fmt.Errorf("error running etcdctl snapshot restore: %w", err)
+		return fmt.Errorf("error running %s snapshot restore: %w", restoreCommand, err)
 	}
 	processState, err := c.Process.Wait()
 	if err != nil {
-		return fmt.Errorf("etcdctl snapshot restore returned an error: %w", err)
+		return fmt.Errorf("%s snapshot restore returned an error: %w", restoreCommand, err)
 	}
 	if !processState.Success() {
-		return fmt.Errorf("etcdctl snapshot restore returned a non-zero exit code")
+		return fmt.Errorf("%s snapshot restore returned a non-zero exit code", restoreCommand)
 	}
 
 	klog.Infof("snapshot restore complete")

--- a/pkg/etcd/etcdprocess_test.go
+++ b/pkg/etcd/etcdprocess_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import "testing"
+
+func TestSnapshotRestoreCommand(t *testing.T) {
+	grid := []struct {
+		etcdVersion string
+		expected    string
+	}{
+		{
+			etcdVersion: "3.5.7",
+			expected:    "etcdctl",
+		},
+		{
+			etcdVersion: "3.6.0",
+			expected:    "etcdutl",
+		},
+		{
+			etcdVersion: "3.6.6",
+			expected:    "etcdutl",
+		},
+		{
+			etcdVersion: "v3.6.6",
+			expected:    "etcdutl",
+		},
+		{
+			etcdVersion: "unknown",
+			expected:    "etcdctl",
+		},
+	}
+
+	for _, g := range grid {
+		t.Run(g.etcdVersion, func(t *testing.T) {
+			p := &etcdProcess{EtcdVersion: g.etcdVersion}
+			if actual := p.snapshotRestoreCommand(); actual != g.expected {
+				t.Fatalf("expected %q, got %q", g.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
etcd 3.6 removed `etcdctl snapshot restore`; restores now need to use `etcdutl snapshot restore`.

  This was observed while running `etcd-manager-ctl restore-backup` after moving to kOps 1.35.0 with `etcd-manager-slim` v3.0.20260227 and etcd 3.6.5/3.6.6. The restore command repeatedly failed with `unknown
  flag: --name` because etcd-manager invoked `etcdctl snapshot restore`.

  etcd-manager currently always invokes `etcdctl` in `RestoreV3Snapshot`. This PR selects `etcdutl` for snapshot restore when the etcd version is 3.6 or newer, while keeping `etcdctl` for older versions. The
  restore arguments are unchanged because `etcdutl snapshot restore` supports the same restore flags used here.

  Tested:
  * Added unit coverage for restore binary selection.
  * `go test -v -short ./pkg/etcd`

/cc @hakman @rifelpet