### PR TITLE
Make etcd membership changes resilient to an unreachable member

### DIFF
--- a/pkg/controller/etcdclusterstate.go
+++ b/pkg/controller/etcdclusterstate.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"time"
 
 	"k8s.io/klog/v2"
 	protoetcd "sigs.k8s.io/etcd-manager/pkg/apis/etcd"
@@ -124,6 +125,9 @@ func (s *etcdClusterState) newEtcdClient(member *etcdclient.EtcdProcessMember) (
 	return etcdClient, err
 }
 
+// memberReconfigureTimeout bounds one etcd membership RPC so a dead member can't drain the budget.
+const memberReconfigureTimeout = 10 * time.Second
+
 func (s *etcdClusterState) etcdAddMember(ctx context.Context, nodeInfo *protoetcd.EtcdNode) (*etcdclient.EtcdProcessMember, error) {
 	for _, member := range s.members {
 		etcdClient, err := s.newEtcdClient(member)
@@ -132,7 +136,9 @@ func (s *etcdClusterState) etcdAddMember(ctx context.Context, nodeInfo *protoetc
 			continue
 		}
 
-		err = etcdClient.AddMember(ctx, nodeInfo.PeerUrls)
+		attemptCtx, cancel := context.WithTimeout(ctx, memberReconfigureTimeout)
+		err = etcdClient.AddMember(attemptCtx, nodeInfo.PeerUrls)
+		cancel()
 		etcdclient.LoggedClose(etcdClient)
 		if err != nil {
 			klog.Warningf("unable to add member %s on peer %s: %v", nodeInfo.PeerUrls, member.Name, err)
@@ -152,7 +158,9 @@ func (s *etcdClusterState) etcdRemoveMember(ctx context.Context, nodeInfo *etcdc
 			continue
 		}
 
-		err = etcdClient.RemoveMember(ctx, nodeInfo)
+		attemptCtx, cancel := context.WithTimeout(ctx, memberReconfigureTimeout)
+		err = etcdClient.RemoveMember(attemptCtx, nodeInfo)
+		cancel()
 		etcdclient.LoggedClose(etcdClient)
 		if err != nil {
 			klog.Warningf("Remove member call failed on %s: %v", id, err)

--- a/pkg/etcdclient/client.go
+++ b/pkg/etcdclient/client.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -29,6 +30,7 @@ import (
 	"strings"
 	"time"
 
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/api/v3/version"
 	etcd_client_v3 "go.etcd.io/etcd/client/v3"
 	"k8s.io/klog/v2"
@@ -252,6 +254,10 @@ func (c *EtcdClient) LeaderID(ctx context.Context) (string, error) {
 
 func (c *EtcdClient) AddMember(ctx context.Context, peerURLs []string) error {
 	_, err := c.cluster.MemberAdd(ctx, peerURLs)
+	// A prior attempt may have committed the add; treat an already-present member as success.
+	if errors.Is(err, rpctypes.ErrMemberExist) || errors.Is(err, rpctypes.ErrPeerURLExist) {
+		return nil
+	}
 	return err
 }
 
@@ -262,6 +268,10 @@ func (c *EtcdClient) SetPeerURLs(ctx context.Context, member *EtcdProcessMember,
 
 func (c *EtcdClient) RemoveMember(ctx context.Context, member *EtcdProcessMember) error {
 	_, err := c.cluster.MemberRemove(ctx, member.idv3)
+	// A prior attempt may have committed the removal; treat an already-removed member as success.
+	if errors.Is(err, rpctypes.ErrMemberNotFound) {
+		return nil
+	}
 	return err
 }
 


### PR DESCRIPTION
`etcdAddMember`/`etcdRemoveMember` passed the shared reconcile context to the membership RPC for every member in turn. The etcd client retries an unreachable endpoint until that context expires, so the first dead member (e.g. the one being replaced) drained the whole budget and the call failed with "unable to reach any cluster member" despite a quorum. This stalled empty-disk replacement recovery, timing out `TestEmptyDiskReplacementRecovery` at 360s.

- Bound each per-member RPC with its own 10s timeout so a dead member fails fast and the loop falls through to a live one (matches the existing `hasEtcdLeader` precedent).
- Treat already-applied changes as success — `AddMember` ignores `ErrMemberExist`/ `ErrPeerURLExist`, `RemoveMember` ignores `ErrMemberNotFound` — so retries are idempotent if an attempt commits server-side but the client times out.

/cc @justinsb @rifelpet @ameukam