### PR TITLE
privateapi: seed self into peers to avoid discovery self-wait

### DIFF
--- a/cmd/etcd-manager/main.go
+++ b/cmd/etcd-manager/main.go
@@ -614,10 +614,9 @@ func RunEtcdManager(o *EtcdManagerOptions) error {
 	if err != nil {
 		return fmt.Errorf("error building etcd controller: %v", err)
 	}
-	go func() {
-		time.Sleep(2 * time.Second) // Gives a bit of time for discovery to run first
-		c.Run(ctx)
-	}()
+	// Self is seeded into the peer set at construction (NewServer), so the controller finds itself on
+	// its first run; no need to wait for discovery.
+	go c.Run(ctx)
 
 	if err := peerServer.ListenAndServe(ctx, grpcEndpoint); err != nil {
 		if ctx.Err() == nil {

--- a/pkg/privateapi/peers.go
+++ b/pkg/privateapi/peers.go
@@ -128,6 +128,25 @@ func (s *Server) updateFromDiscovery(discoveryNode discovery.Node) {
 	}
 }
 
+// addSelf registers our identity as a peer immediately and marks it healthy, so Peers() includes us
+// without waiting for discovery to report us back. A loopback self-ping keeps it healthy, like any
+// discovered peer; other peers still come only from discovery.
+func (s *Server) addSelf() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	id := PeerId(s.myInfo.Id)
+	klog.Infof("adding self as peer: %s %v", id, s.myInfo.Endpoints)
+	self := &peer{
+		server:      s,
+		id:          id,
+		defaultPort: s.defaultPort,
+	}
+	self.updatePeerInfo(s.myInfo)
+	s.peers[id] = self
+	go self.Run(s.context, s.PingInterval)
+}
+
 func (s *Server) runDiscoveryOnce() error {
 	nodes, err := s.discovery.Poll()
 	if err != nil {

--- a/pkg/privateapi/server.go
+++ b/pkg/privateapi/server.go
@@ -98,6 +98,9 @@ func NewServer(ctx context.Context, myInfo *PeerInfo, serverTLSConfig *tls.Confi
 
 	s.grpcServer = grpc.NewServer(opts...)
 
+	// Register ourselves as a peer immediately, so Peers() includes us without waiting for discovery.
+	s.addSelf()
+
 	return s, nil
 }
 

--- a/pkg/privateapi/server_test.go
+++ b/pkg/privateapi/server_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package privateapi
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/etcd-manager/pkg/privateapi/discovery"
+)
+
+// fakeDiscovery is a discovery.Interface that returns a fixed set of nodes.
+type fakeDiscovery struct {
+	nodes map[string]discovery.Node
+	err   error
+}
+
+func (f *fakeDiscovery) Poll() (map[string]discovery.Node, error) {
+	return f.nodes, f.err
+}
+
+func newTestServer(t *testing.T, ctx context.Context, disco discovery.Interface) *Server {
+	t.Helper()
+
+	myInfo := &PeerInfo{
+		Id:        "self",
+		Endpoints: []string{"127.0.0.1:8000"},
+	}
+	// dnsProvider/dnsSuffix and TLS configs are unused: no DNS suffix, connections are insecure.
+	s, err := NewServer(ctx, myInfo, nil, disco, 8000, nil, "", nil, time.Minute)
+	if err != nil {
+		t.Fatalf("NewServer failed: %v", err)
+	}
+	return s
+}
+
+// TestServerSeedsSelfIntoPeers verifies Peers() includes self immediately after construction.
+func TestServerSeedsSelfIntoPeers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := newTestServer(t, ctx, &fakeDiscovery{nodes: map[string]discovery.Node{}})
+
+	peers := s.Peers()
+	if len(peers) != 1 {
+		t.Fatalf("expected exactly 1 peer (self), got %d: %v", len(peers), peers)
+	}
+	if PeerId(peers[0].Id) != s.MyPeerId() {
+		t.Fatalf("expected peer to be self %q, got %q", s.MyPeerId(), peers[0].Id)
+	}
+}
+
+// TestDiscoveryAddsOtherPeers checks that seeding self still lets discovery add other peers.
+func TestDiscoveryAddsOtherPeers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	disco := &fakeDiscovery{
+		nodes: map[string]discovery.Node{
+			"self":   {ID: "self", Endpoints: []discovery.NodeEndpoint{{IP: "127.0.0.1", Port: 8000}}},
+			"other1": {ID: "other1", Endpoints: []discovery.NodeEndpoint{{IP: "127.0.0.2", Port: 8000}}},
+			"other2": {ID: "other2", Endpoints: []discovery.NodeEndpoint{{IP: "127.0.0.3", Port: 8000}}},
+		},
+	}
+	s := newTestServer(t, ctx, disco)
+
+	if err := s.runDiscoveryOnce(); err != nil {
+		t.Fatalf("runDiscoveryOnce failed: %v", err)
+	}
+
+	hasPeer := func(id PeerId) bool {
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
+		return s.peers[id] != nil
+	}
+	for _, id := range []PeerId{"self", "other1", "other2"} {
+		if !hasPeer(id) {
+			t.Errorf("expected peer %q to be tracked after discovery", id)
+		}
+	}
+}
+
+// TestRunDiscoveryOnceErrorKeepsSelf verifies that a failed first discovery poll (the Azure case
+// where the data disk isn't visible yet) keeps self in the peer list and reports the error.
+func TestRunDiscoveryOnceErrorKeepsSelf(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	disco := &fakeDiscovery{err: fmt.Errorf("no data disk found")}
+	s := newTestServer(t, ctx, disco)
+
+	if err := s.runDiscoveryOnce(); err == nil {
+		t.Fatal("expected error from runDiscoveryOnce when discovery poll fails")
+	}
+
+	peers := s.Peers()
+	if len(peers) != 1 || PeerId(peers[0].Id) != s.MyPeerId() {
+		t.Fatalf("expected self to remain the only peer after failed discovery, got %v", peers)
+	}
+}


### PR DESCRIPTION
## Problem

On a single-member first start, the controller can't act until peer discovery returns its own node. On Azure that's **~62s of the ~97s cold start**: the first discovery poll fails (data disk not yet visible) and `DiscoveryPollInterval` is 60s, so the controller logs `cannot find self in list of peers []` every 10s until the next poll. AWS/GCE return self on the first poll and don't stall.

## Change

Seed our own identity into the peer set at construction (`NewServer.addSelf`), marked healthy and kept alive by the normal loopback self-ping, so `Peers()` includes self without waiting for discovery. The controller's first run now finds itself immediately. Other peers still come only from discovery, and the flat 2s pre-controller sleep is dropped.

Only `cmd/etcd-manager/main.go` and `pkg/privateapi/*` change; discovery cadence is unchanged.

## Safety

Leader election is untouched (lowest-id election, `BecomeLeader` all-peers-ack with omitted-peer reject, resign-on-unacked). The "`Peers()` = self only" state is already reachable on AWS/GCE cold starts, so this adds no new state — self just appears sooner, and the protocol self-corrects. Quorum/quarantine unchanged.

## Tests

New `pkg/privateapi/server_test.go`: self present immediately after construction, discovery still adds other peers, self survives a failed first poll. Full suite passes including `test/integration` (multi-member formation + split-brain prevention).

Expected saving: **~62s** on Azure single-member cold start.