### PR TITLE
WIP pki: reuse etcd TLS keypairs instead of regenerating on every start

### DIFF
--- a/pkg/etcd/pki.go
+++ b/pkg/etcd/pki.go
@@ -109,18 +109,16 @@ func (p *etcdProcess) createKeypairs(peersCA *pki.CA, clientsCA *pki.CA, pkiDir 
 		if err != nil {
 			return err
 		}
-	} else {
-		klog.Warningf("not generating client keypair as clients-ca not set")
-	}
 
-	if clientsCA != nil {
-		keypairs := pki.NewKeypairs(pki.NewInMemoryStore(), clientsCA)
-
+		// Build the client TLS config from the on-disk store (not an in-memory one) so the expensive
+		// RSA client key is generated once and reused across restarts instead of on every start.
 		c, err := BuildTLSClientConfig(keypairs, me.Name)
 		if err != nil {
 			return err
 		}
 		p.etcdClientTLSConfig = c
+	} else {
+		klog.Warningf("not generating client keypair as clients-ca not set")
 	}
 
 	return nil

--- a/pkg/etcd/pki_test.go
+++ b/pkg/etcd/pki_test.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	protoetcd "sigs.k8s.io/etcd-manager/pkg/apis/etcd"
+	"sigs.k8s.io/etcd-manager/pkg/pki"
+)
+
+// TestCreateKeypairsReuse verifies that a second createKeypairs call with identical inputs and
+// the same pkiDir (an etcd restart) regenerates no key and re-signs no certificate, and that the
+// persisted keypairs stay valid for etcd's peer and client TLS roles.
+func TestCreateKeypairsReuse(t *testing.T) {
+	peersCA, clientsCA := setupTestCAs(t)
+	pkiDir := t.TempDir()
+
+	me := &protoetcd.EtcdNode{
+		Name: "node1",
+		// Peer and client URLs share a host, so the cert gets duplicate SAN DNS names (as in
+		// production); this checks the reuse/match logic is stable in that case.
+		PeerUrls:   []string{"https://node1:2380"},
+		ClientUrls: []string{"https://node1:2379"},
+	}
+	peerClientIPs := []net.IP{net.ParseIP("10.0.0.1")}
+
+	// First start generates the peer ("me"), client-serving ("server") and client keypairs.
+	if err := (&etcdProcess{}).createKeypairs(peersCA, clientsCA, pkiDir, me, peerClientIPs); err != nil {
+		t.Fatalf("first createKeypairs: %v", err)
+	}
+
+	files := []string{
+		filepath.Join("peers", "me.key"),
+		filepath.Join("peers", "me.crt"),
+		filepath.Join("clients", "server.key"),
+		filepath.Join("clients", "server.crt"),
+		filepath.Join("clients", "client.key"),
+		filepath.Join("clients", "client.crt"),
+	}
+
+	// The client keypair must be persisted under pkiDir; it used to be held in an in-memory
+	// store and regenerated on every start.
+	if _, err := os.Stat(filepath.Join(pkiDir, "clients", "client.key")); err != nil {
+		t.Fatalf("client key was not persisted under pkiDir: %v", err)
+	}
+
+	before := make(map[string][]byte, len(files))
+	for _, f := range files {
+		before[f] = mustReadFile(t, filepath.Join(pkiDir, f))
+	}
+
+	// Second start with identical inputs and the same pkiDir must not regenerate any key or
+	// re-sign any certificate.
+	p2 := &etcdProcess{}
+	if err := p2.createKeypairs(peersCA, clientsCA, pkiDir, me, peerClientIPs); err != nil {
+		t.Fatalf("second createKeypairs: %v", err)
+	}
+	for _, f := range files {
+		after := mustReadFile(t, filepath.Join(pkiDir, f))
+		if !bytes.Equal(before[f], after) {
+			t.Errorf("%s changed between calls: key was regenerated or certificate re-signed", f)
+		}
+	}
+
+	// Each cert must validate against its CA for the TLS roles etcd needs: the peer and server
+	// certs serve and dial; the client cert is what etcd-manager uses to talk to etcd.
+	verifyCertFile(t, filepath.Join(pkiDir, "peers", "me.crt"), peersCA, x509.ExtKeyUsageServerAuth)
+	verifyCertFile(t, filepath.Join(pkiDir, "peers", "me.crt"), peersCA, x509.ExtKeyUsageClientAuth)
+	verifyCertFile(t, filepath.Join(pkiDir, "clients", "server.crt"), clientsCA, x509.ExtKeyUsageServerAuth)
+	verifyCertFile(t, filepath.Join(pkiDir, "clients", "server.crt"), clientsCA, x509.ExtKeyUsageClientAuth)
+	verifyCertFile(t, filepath.Join(pkiDir, "clients", "client.crt"), clientsCA, x509.ExtKeyUsageClientAuth)
+
+	// The TLS config used to dial etcd must be populated, and its leaf must be the persisted
+	// client certificate, valid for client auth.
+	if p2.etcdClientTLSConfig == nil || len(p2.etcdClientTLSConfig.Certificates) == 0 {
+		t.Fatalf("etcdClientTLSConfig was not populated")
+	}
+	leaf := p2.etcdClientTLSConfig.Certificates[0].Leaf
+	if leaf == nil {
+		t.Fatalf("etcdClientTLSConfig leaf certificate not set")
+	}
+	verifyCert(t, leaf, clientsCA, x509.ExtKeyUsageClientAuth)
+}
+
+// TestCreateKeypairsServeMutualTLS confirms the persisted (reused) server and client certs
+// complete a real mutual TLS handshake the way etcd uses them: the server serves with the "server"
+// keypair and verifies the "client" keypair against the clients CA. This exercises key/cert
+// pairing, certificate chaining, and the ServerAuth/ClientAuth usages without an etcd binary.
+func TestCreateKeypairsServeMutualTLS(t *testing.T) {
+	peersCA, clientsCA := setupTestCAs(t)
+	pkiDir := t.TempDir()
+
+	me := &protoetcd.EtcdNode{
+		Name:       "node1",
+		PeerUrls:   []string{"https://127.0.0.1:2380"},
+		ClientUrls: []string{"https://127.0.0.1:2379"},
+	}
+	if err := (&etcdProcess{}).createKeypairs(peersCA, clientsCA, pkiDir, me, nil); err != nil {
+		t.Fatalf("createKeypairs: %v", err)
+	}
+
+	// LoadX509KeyPair also confirms each persisted key matches its certificate.
+	serverPair, err := tls.LoadX509KeyPair(
+		filepath.Join(pkiDir, "clients", "server.crt"),
+		filepath.Join(pkiDir, "clients", "server.key"))
+	if err != nil {
+		t.Fatalf("loading persisted server keypair: %v", err)
+	}
+	clientPair, err := tls.LoadX509KeyPair(
+		filepath.Join(pkiDir, "clients", "client.crt"),
+		filepath.Join(pkiDir, "clients", "client.key"))
+	if err != nil {
+		t.Fatalf("loading persisted client keypair: %v", err)
+	}
+
+	caPool := clientsCA.CertPool()
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverPair},
+		ClientCAs:    caPool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+	}
+	srv.StartTLS()
+	defer srv.Close()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:      caPool,
+				Certificates: []tls.Certificate{clientPair},
+			},
+		},
+	}
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("mutual TLS handshake with reused etcd certs failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status from TLS server: %d", resp.StatusCode)
+	}
+}
+
+// setupTestCAs shrinks the RSA key size for speed (restoring it afterwards) and builds the peer
+// and client CAs, which in production are loaded from disk and stable across restarts.
+func setupTestCAs(t *testing.T) (peersCA, clientsCA *pki.CA) {
+	t.Helper()
+	pki.SetRSAKeySize(2048)
+	t.Cleanup(func() { pki.SetRSAKeySize(4096) })
+
+	peersCA, err := pki.NewCA(pki.NewInMemoryStore())
+	if err != nil {
+		t.Fatalf("building peers CA: %v", err)
+	}
+	clientsCA, err = pki.NewCA(pki.NewInMemoryStore())
+	if err != nil {
+		t.Fatalf("building clients CA: %v", err)
+	}
+	return peersCA, clientsCA
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %q: %v", path, err)
+	}
+	return b
+}
+
+func verifyCertFile(t *testing.T, path string, ca *pki.CA, usage x509.ExtKeyUsage) {
+	t.Helper()
+	cert, err := pki.ParseOneCertificate(mustReadFile(t, path))
+	if err != nil {
+		t.Fatalf("parsing %q: %v", path, err)
+	}
+	verifyCert(t, cert, ca, usage)
+}
+
+func verifyCert(t *testing.T, cert *x509.Certificate, ca *pki.CA, usage x509.ExtKeyUsage) {
+	t.Helper()
+	if _, err := cert.Verify(x509.VerifyOptions{
+		Roots:     ca.CertPool(),
+		KeyUsages: []x509.ExtKeyUsage{usage},
+	}); err != nil {
+		t.Errorf("certificate %q failed to verify against CA (usage %v): %v", cert.Subject.CommonName, usage, err)
+	}
+}

--- a/pkg/pki/certs.go
+++ b/pkg/pki/certs.go
@@ -37,10 +37,10 @@ import (
 // it to two years, with kubernetes LTS proposing one year's support.
 var CertDuration = 2 * 365 * 24 * time.Hour
 
-// CertMinTimeLeft is the minimum amount of validity required on
-// a certificate to reuse it.  Because we set this (much) higher than
-// CertDuration, we will now always reissue certificates.
-var CertMinTimeLeft = 20 * 365 * 24 * time.Hour
+// CertMinTimeLeft is the minimum validity a certificate must have left for us to reuse it; once
+// less remains we renew it. It must be shorter than CertDuration, otherwise a freshly-issued
+// certificate looks like it is expiring and gets reissued on every start.
+var CertMinTimeLeft = CertDuration / 3
 
 // ParseHumanDuration parses a go-style duration string, but
 // recognizes additional suffixes: d means "day" and is interpreted as
@@ -75,6 +75,9 @@ func init() {
 			klog.Fatalf("failed to parse ETCD_MANAGER_CERT_DURATION=%q", s)
 		}
 		CertDuration = v
+		// Keep the renewal threshold proportional to the overridden lifetime; an explicit
+		// ETCD_MANAGER_CERT_MIN_TIME_LEFT below still wins.
+		CertMinTimeLeft = CertDuration / 3
 	}
 
 	if s := os.Getenv("ETCD_MANAGER_CERT_MIN_TIME_LEFT"); s != "" {
@@ -146,6 +149,15 @@ func ensureKeypair(store MutableKeypair, config certutil.Config, signer *CA) (*K
 			cert := keypair.Certificate
 
 			match := true
+
+			// Reuse the certificate only if it still chains to the current CA; after a CA rotation
+			// (or if it was issued by a different CA) it would fail validation, so reissue it.
+			if match {
+				if err := cert.CheckSignatureFrom(signer.primaryCertificate); err != nil {
+					klog.Infof("existing certificate for %q is not signed by the current CA; will regenerate", p)
+					match = false
+				}
+			}
 
 			if match && time.Until(cert.NotAfter) <= CertMinTimeLeft {
 				klog.Infof("existing certificate not valid after %s; will regenerate", cert.NotAfter.Format(time.RFC3339))

--- a/pkg/pki/certs_test.go
+++ b/pkg/pki/certs_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pki
+
+import (
+	"bytes"
+	"crypto/x509"
+	"os"
+	"path/filepath"
+	"testing"
+
+	certutil "k8s.io/client-go/util/cert"
+)
+
+// TestCertMinTimeLeftLessThanDuration guards against CertMinTimeLeft >= CertDuration, which makes
+// every freshly-issued certificate look like it is expiring and forces a re-sign on every start.
+func TestCertMinTimeLeftLessThanDuration(t *testing.T) {
+	if CertMinTimeLeft >= CertDuration {
+		t.Fatalf("CertMinTimeLeft (%s) must be less than CertDuration (%s); otherwise valid certificates are reissued on every start", CertMinTimeLeft, CertDuration)
+	}
+}
+
+// TestEnsureKeypairReusesCertAndKey verifies that a still-valid cert and its key are reused (not
+// regenerated or re-signed) when the same CA is presented again, and that a CA rotation reissues
+// the certificate while still reusing the (CA-independent) private key.
+func TestEnsureKeypairReusesCertAndKey(t *testing.T) {
+	SetRSAKeySize(2048)
+	t.Cleanup(func() { SetRSAKeySize(4096) })
+
+	dir := t.TempDir()
+	ca, err := NewCA(NewInMemoryStore())
+	if err != nil {
+		t.Fatalf("building CA: %v", err)
+	}
+
+	config := certutil.Config{
+		CommonName: "test-client",
+		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	keyPath := filepath.Join(dir, "test-client.key")
+	crtPath := filepath.Join(dir, "test-client.crt")
+
+	// First call generates the key and signs the certificate.
+	kp1, err := NewKeypairs(NewFSStore(dir), ca).EnsureKeypair("test-client", config)
+	if err != nil {
+		t.Fatalf("first EnsureKeypair: %v", err)
+	}
+	key1 := mustReadFile(t, keyPath)
+	crt1 := mustReadFile(t, crtPath)
+	verifyCertAgainstCA(t, kp1.Certificate, ca, x509.ExtKeyUsageClientAuth)
+
+	// Second call with a fresh Keypairs over the same on-disk store and CA models an etcd restart:
+	// it must reuse both the key and the certificate.
+	kp2, err := NewKeypairs(NewFSStore(dir), ca).EnsureKeypair("test-client", config)
+	if err != nil {
+		t.Fatalf("second EnsureKeypair: %v", err)
+	}
+	key2 := mustReadFile(t, keyPath)
+	crt2 := mustReadFile(t, crtPath)
+
+	if !bytes.Equal(key1, key2) {
+		t.Errorf("private key was regenerated when it should have been reused")
+	}
+	if !bytes.Equal(crt1, crt2) {
+		t.Errorf("certificate was re-signed when it should have been reused")
+	}
+	if !kp1.Certificate.Equal(kp2.Certificate) {
+		t.Errorf("returned certificate differs across calls")
+	}
+
+	// Rotate the CA: a new CA over the same store must reissue the cert (it no longer chains to the
+	// old signer) while reusing the private key.
+	ca2, err := NewCA(NewInMemoryStore())
+	if err != nil {
+		t.Fatalf("building rotated CA: %v", err)
+	}
+	kp3, err := NewKeypairs(NewFSStore(dir), ca2).EnsureKeypair("test-client", config)
+	if err != nil {
+		t.Fatalf("EnsureKeypair after CA rotation: %v", err)
+	}
+	key3 := mustReadFile(t, keyPath)
+	crt3 := mustReadFile(t, crtPath)
+
+	if !bytes.Equal(key2, key3) {
+		t.Errorf("private key should be reused across a CA rotation")
+	}
+	if bytes.Equal(crt2, crt3) {
+		t.Errorf("certificate was not reissued after a CA rotation")
+	}
+	// The reissued cert must validate against the new CA and must not validate against the old one.
+	verifyCertAgainstCA(t, kp3.Certificate, ca2, x509.ExtKeyUsageClientAuth)
+	if _, err := kp3.Certificate.Verify(x509.VerifyOptions{
+		Roots:     ca.CertPool(),
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}); err == nil {
+		t.Errorf("reissued certificate unexpectedly validates against the old CA")
+	}
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %q: %v", path, err)
+	}
+	return b
+}
+
+func verifyCertAgainstCA(t *testing.T, cert *x509.Certificate, ca *CA, usage x509.ExtKeyUsage) {
+	t.Helper()
+	if _, err := cert.Verify(x509.VerifyOptions{
+		Roots:     ca.CertPool(),
+		KeyUsages: []x509.ExtKeyUsage{usage},
+	}); err != nil {
+		t.Errorf("certificate %q failed to verify against CA: %v", cert.Subject.CommonName, err)
+	}
+}


### PR DESCRIPTION
## What this does

Cuts the TLS certificate-generation cost on etcd start. 4096-bit RSA keygen is single-threaded and CPU-bound (~2.7s/key on a 2-vCPU control plane), and cert generation is the dominant cold-start cost on slow CPUs. This PR touches only the PKI/cert code.

### 1. Stop regenerating the etcd-client keypair on every start

`createKeypairs` built the etcd client TLS config from an **in-memory** PKI store, so a fresh 4096-bit RSA key was generated on **every** etcd `(re)start`. etcd is restarted several times during bring-up and on crash recovery, making this the single most expensive repeated keygen.

The client keypair is now backed by the on-disk `FSStore` under `pkiDir` (the same pattern already used for the `peers`/`clients` keypairs), so the key is generated once and reused across restarts. The client cert's CN (`me.Name`) and usage (`ClientAuth`) are unchanged.

### 2. Fix the cert-reuse freshness check (it always failed)

`CertMinTimeLeft` (the renewal threshold) was **20 years** while `CertDuration` is **2 years**, so the reuse check `time.Until(cert.NotAfter) <= CertMinTimeLeft` was always true and `ensureKeypair` re-signed the certificate on **every** call — `generating certificate for ...` was logged on every start even when the key was reused. `CertMinTimeLeft` is now `CertDuration/3`, so a still-valid persisted certificate is reused. The `ETCD_MANAGER_CERT_DURATION` / `ETCD_MANAGER_CERT_MIN_TIME_LEFT` env overrides still work.

### 3. Verify a reused cert still chains to the current CA

Now that certificates are actually reused, `ensureKeypair` also checks that the persisted certificate is signed by the current signing CA (`CheckSignatureFrom`) before reusing it. Without this, a CA rotation — or the ephemeral CA used on the snapshot-restore path — would reuse a certificate that no longer validates against the current CA bundle. The old always-regenerate behaviour accidentally masked this; the new check forces a reissue (key is still reused) when the signer changes.

## Why it's safe

- Key size, key usages, and certificate validity are all unchanged.
- In production the etcd CAs are loaded from the persistent FS store and `pkiDir` is keyed by the stable cluster token, so reusing keypairs across restarts is valid.
- The new signature check covers the CA-rotation and ephemeral-CA (restore) edge cases, so we never serve a leaf that fails to chain to the configured CA.

## Expected savings

~5–14s on first start (CPU-dependent), from removing the repeated client-key generation across the multiple etcd restarts during bring-up, plus a redundant ~1–5s keygen removed from every later restart / crash recovery. Helps all cloud providers; the effect is largest on 2-vCPU control planes.

## Tests

- `pkg/pki`: a still-valid cert + key are reused (not re-signed) on a second `EnsureKeypair` with the same CA; a CA rotation forces a reissue while reusing the (CA-independent) private key; a guard asserting `CertMinTimeLeft < CertDuration`.
- `pkg/etcd`: a second `createKeypairs` with identical inputs and the same `pkiDir` does not regenerate any key or re-sign any cert; the client key is persisted under `pkiDir`; and the peer/server/client certs still validate for etcd's peer and client TLS roles.

```
go build ./...
go test ./pkg/pki/... ./pkg/etcd/...
```

## Possible follow-up (not in this PR)

The three independent startup keypairs (peer `me`, client-serving `server`, client) could be generated concurrently to cut first-boot wall-clock further on multi-vCPU boxes. Left out here to keep the change minimal and avoid adding concurrency to the security-critical cert path; happy to do it as a follow-up.
