### PR TITLE
controller: skip post-election wait for single-member clusters

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -254,8 +254,12 @@ func (m *EtcdController) run(ctx context.Context) (bool, error) {
 		// TODO: How do we lose leadership
 		m.peerState = make(map[privateapi.PeerId]*peerState)
 
-		// Wait one cycle after a new leader election
-		return false, nil
+		// Normally we wait a cycle after a leader election so our leadership claim can propagate.
+		// A single-member cluster with no leader lock has no competing leader, so skip that wait.
+		spec := m.getControlClusterSpec()
+		if m.leaderLock != nil || spec == nil || spec.MemberCount != 1 {
+			return false, nil
+		}
 	}
 
 	{


### PR DESCRIPTION
For a fresh single-member cluster (clusterSpec.MemberCount==1) with no external leader lock there is no competing leader to coordinate with, so the one-cycle "wait after leader election" stall (a fixed ~10s) is pure latency. Skip it in that case; multi-member clusters, clusters using a leader lock, and an unknown cluster spec keep the wait.

/cc @rifelpet @ameukam 