### PR TITLE
pki: use ECDSA P-256 for leaf keys, keep RSA for CAs

### DIFF
--- a/pkg/pki/cas.go
+++ b/pkg/pki/cas.go
@@ -17,13 +17,13 @@ limitations under the License.
 package pki
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"crypto/x509"
 )
 
 type CA struct {
 	primaryCertificate *x509.Certificate
-	privateKey         *rsa.PrivateKey
+	privateKey         crypto.Signer
 	certificates       []*x509.Certificate
 }
 

--- a/pkg/pki/certs.go
+++ b/pkg/pki/certs.go
@@ -17,7 +17,9 @@ limitations under the License.
 package pki
 
 import (
-	"crypto/rsa"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/x509"
 	"fmt"
 	"os"
@@ -88,7 +90,7 @@ func init() {
 
 type Keypair struct {
 	Certificate *x509.Certificate
-	PrivateKey  *rsa.PrivateKey
+	PrivateKey  crypto.Signer
 }
 
 type MutableKeypair interface {
@@ -101,7 +103,7 @@ func NewCA(s Store) (*CA, error) {
 	p := config.CommonName
 
 	mutator := func(keypair *Keypair) error {
-		privateKey, err := newPrivateKey()
+		privateKey, err := newCAPrivateKey()
 		if err != nil {
 			return fmt.Errorf("unable to create private key %q: %w", p, err)
 		}
@@ -134,8 +136,12 @@ func ensureKeypair(store MutableKeypair, config certutil.Config, signer *CA) (*K
 	p := config.CommonName
 
 	mutator := func(keypair *Keypair) error {
-		if keypair.PrivateKey == nil {
-			privateKey, err := newPrivateKey()
+		if ecdsaKey, ok := keypair.PrivateKey.(*ecdsa.PrivateKey); !ok || ecdsaKey.Curve != elliptic.P256() {
+			if keypair.PrivateKey != nil {
+				klog.Infof("existing private key for %q is not ECDSA P-256; will regenerate", p)
+				keypair.Certificate = nil
+			}
+			privateKey, err := newLeafPrivateKey()
 			if err != nil {
 				return fmt.Errorf("unable to create private key %q: %w", p, err)
 			}

--- a/pkg/pki/certs_test.go
+++ b/pkg/pki/certs_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pki
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	certutil "k8s.io/client-go/util/cert"
+)
+
+func TestNewCAIsRSA(t *testing.T) {
+	SetRSAKeySize(2048)
+
+	ca, err := NewCA(NewInMemoryStore())
+	if err != nil {
+		t.Fatalf("failed to create CA: %v", err)
+	}
+	if _, ok := ca.privateKey.(*rsa.PrivateKey); !ok {
+		t.Fatalf("expected RSA CA private key, got %T", ca.privateKey)
+	}
+}
+
+func TestEnsureKeypairGeneratesECDSA(t *testing.T) {
+	SetRSAKeySize(2048)
+
+	ca, err := NewCA(NewInMemoryStore())
+	if err != nil {
+		t.Fatalf("failed to create CA: %v", err)
+	}
+
+	keypairs := NewKeypairs(NewInMemoryStore(), ca)
+	keypair, err := keypairs.EnsureKeypair("test-cert", certutil.Config{
+		CommonName: "test-cert",
+		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	if err != nil {
+		t.Fatalf("ensuring keypair: %v", err)
+	}
+
+	ecdsaKey, ok := keypair.PrivateKey.(*ecdsa.PrivateKey)
+	if !ok {
+		t.Fatalf("expected ECDSA private key, got %T", keypair.PrivateKey)
+	}
+	if ecdsaKey.Curve != elliptic.P256() {
+		t.Fatalf("expected P-256 curve, got %v", ecdsaKey.Curve)
+	}
+	if !ecdsaKey.PublicKey.Equal(keypair.Certificate.PublicKey) {
+		t.Fatalf("certificate public key does not match private key")
+	}
+	if keypair.Certificate.KeyUsage != x509.KeyUsageDigitalSignature {
+		t.Fatalf("unexpected key usage %v", keypair.Certificate.KeyUsage)
+	}
+}
+
+// TestEnsureKeypairMigratesRSAToECDSA verifies that a pre-existing RSA leaf
+// keypair on disk (as written by older etcd-manager versions) is replaced
+// with an ECDSA P-256 keypair, and that the reissued certificate still
+// verifies against the (RSA) CA.
+func TestEnsureKeypairMigratesRSAToECDSA(t *testing.T) {
+	SetRSAKeySize(2048)
+
+	tempDir := t.TempDir()
+
+	ca, err := NewCA(NewInMemoryStore())
+	if err != nil {
+		t.Fatalf("failed to create CA: %v", err)
+	}
+
+	config := certutil.Config{
+		CommonName: "test-cert",
+		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	// Write an RSA leaf keypair in the legacy on-disk format
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(rsaKey)})
+	if err := os.WriteFile(filepath.Join(tempDir, "test-cert.key"), keyPEM, 0600); err != nil {
+		t.Fatalf("failed to write key: %v", err)
+	}
+	rsaCert, err := newSignedCert(&config, rsaKey, ca, CertDuration)
+	if err != nil {
+		t.Fatalf("failed to sign RSA certificate: %v", err)
+	}
+	if err := writeCertificates(filepath.Join(tempDir, "test-cert.crt"), rsaCert); err != nil {
+		t.Fatalf("failed to write certificate: %v", err)
+	}
+
+	keypairs := NewKeypairs(NewFSStore(tempDir), ca)
+	keypair, err := keypairs.EnsureKeypair("test-cert", config)
+	if err != nil {
+		t.Fatalf("ensuring keypair: %v", err)
+	}
+
+	ecdsaKey, ok := keypair.PrivateKey.(*ecdsa.PrivateKey)
+	if !ok {
+		t.Fatalf("expected ECDSA private key after migration, got %T", keypair.PrivateKey)
+	}
+	if ecdsaKey.Curve != elliptic.P256() {
+		t.Fatalf("expected P-256 curve, got %v", ecdsaKey.Curve)
+	}
+	if !ecdsaKey.PublicKey.Equal(keypair.Certificate.PublicKey) {
+		t.Fatalf("certificate public key does not match private key")
+	}
+
+	if _, err := keypair.Certificate.Verify(x509.VerifyOptions{
+		Roots:     ca.CertPool(),
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}); err != nil {
+		t.Fatalf("certificate does not verify against CA: %v", err)
+	}
+
+	// The key on disk should round-trip as the same ECDSA key
+	loadedKey, err := loadPrivateKey(filepath.Join(tempDir, "test-cert.key"))
+	if err != nil {
+		t.Fatalf("loading private key: %v", err)
+	}
+	if !privateKeysEqual(loadedKey, keypair.PrivateKey) {
+		t.Fatalf("key on disk does not match returned key")
+	}
+
+	// A subsequent EnsureKeypair must reuse the ECDSA key
+	keypair2, err := keypairs.EnsureKeypair("test-cert", config)
+	if err != nil {
+		t.Fatalf("ensuring keypair again: %v", err)
+	}
+	if !privateKeysEqual(keypair.PrivateKey, keypair2.PrivateKey) {
+		t.Fatalf("private key was unexpectedly regenerated")
+	}
+}

--- a/pkg/pki/certutils.go
+++ b/pkg/pki/certutils.go
@@ -18,6 +18,8 @@ package pki
 
 import (
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	cryptorand "crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -33,9 +35,6 @@ import (
 const (
 	// CertificateBlockType is a possible value for pem.Block.Type.
 	CertificateBlockType = "CERTIFICATE"
-
-	// RSAPrivateKeyBlockType is a possible value for pem.Block.Type.
-	RSAPrivateKeyBlockType = "RSA PRIVATE KEY"
 )
 
 var rsaKeySize = 4096
@@ -45,9 +44,14 @@ func SetRSAKeySize(size int) {
 	rsaKeySize = size
 }
 
-// newPrivateKey creates an RSA private key
-func newPrivateKey() (*rsa.PrivateKey, error) {
+// newCAPrivateKey creates an RSA private key, used for CAs
+func newCAPrivateKey() (*rsa.PrivateKey, error) {
 	return rsa.GenerateKey(cryptorand.Reader, rsaKeySize)
+}
+
+// newLeafPrivateKey creates an ECDSA P-256 private key, used for leaf certificates
+func newLeafPrivateKey() (*ecdsa.PrivateKey, error) {
+	return ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)
 }
 
 // newSignedCert creates a signed certificate using the given CA.
@@ -65,6 +69,12 @@ func newSignedCert(cfg *certutil.Config, key crypto.Signer, ca *CA, duration tim
 		return nil, fmt.Errorf("must specify at least one ExtKeyUsage")
 	}
 
+	keyUsage := x509.KeyUsageDigitalSignature
+	if _, isRSA := key.Public().(*rsa.PublicKey); isRSA {
+		// KeyEncipherment is only meaningful for RSA key transport
+		keyUsage |= x509.KeyUsageKeyEncipherment
+	}
+
 	certTmpl := x509.Certificate{
 		Subject: pkix.Name{
 			CommonName:   cfg.CommonName,
@@ -75,7 +85,7 @@ func newSignedCert(cfg *certutil.Config, key crypto.Signer, ca *CA, duration tim
 		SerialNumber: serial,
 		NotBefore:    caCert.NotBefore,
 		NotAfter:     time.Now().Add(duration).UTC(),
-		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		KeyUsage:     keyUsage,
 		ExtKeyUsage:  cfg.Usages,
 	}
 	certDERBytes, err := x509.CreateCertificate(cryptorand.Reader, &certTmpl, caCert, key.Public(), caKey)

--- a/pkg/pki/fs.go
+++ b/pkg/pki/fs.go
@@ -18,7 +18,7 @@ package pki
 
 import (
 	"bytes"
-	"crypto/rsa"
+	"crypto"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -60,7 +60,7 @@ func (s *MutableKeypairFromFile) MutateKeypair(mutator func(keypair *Keypair) er
 		return nil, err
 	}
 
-	if original.PrivateKey == nil || !original.PrivateKey.Equal(keypair.PrivateKey) {
+	if original.PrivateKey == nil || !privateKeysEqual(original.PrivateKey, keypair.PrivateKey) {
 		if err := writePrivateKey(s.PrivateKeyPath, keypair.PrivateKey); err != nil {
 			return nil, err
 		}
@@ -94,7 +94,18 @@ func (s *FSStore) Keypair(name string) MutableKeypair {
 	}
 }
 
-func writePrivateKey(path string, privateKey *rsa.PrivateKey) error {
+// privateKeysEqual compares two private keys using their Equal method.
+func privateKeysEqual(a, b crypto.Signer) bool {
+	key, ok := a.(interface{ Equal(x crypto.PrivateKey) bool })
+	return ok && key.Equal(b)
+}
+
+func writePrivateKey(path string, privateKey crypto.Signer) error {
+	keyBytes, err := keyutil.MarshalPrivateKeyToPEM(privateKey)
+	if err != nil {
+		return fmt.Errorf("marshalling private key for %q: %w", path, err)
+	}
+
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return fmt.Errorf("creating directories for private key file %q: %w", path, err)
 	}
@@ -104,8 +115,7 @@ func writePrivateKey(path string, privateKey *rsa.PrivateKey) error {
 		return fmt.Errorf("opening private key file %q: %w", path, err)
 	}
 
-	err = pem.Encode(f, &pem.Block{Type: RSAPrivateKeyBlockType, Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
-	if err != nil {
+	if _, err := f.Write(keyBytes); err != nil {
 		_ = f.Close()
 		return fmt.Errorf("writing private key file %q: %w", path, err)
 	}
@@ -167,7 +177,10 @@ func (s *FSStore) LoadCA(name string) (*CA, error) {
 		return bytes.Compare(ca.certificates[i].Raw, ca.certificates[j].Raw) < 0
 	})
 
-	publicKey := ca.privateKey.PublicKey
+	publicKey, ok := ca.privateKey.Public().(interface{ Equal(x crypto.PublicKey) bool })
+	if !ok {
+		return nil, fmt.Errorf("unexpected public key type for %s: %T", name, ca.privateKey.Public())
+	}
 	for _, cert := range ca.certificates {
 		if publicKey.Equal(cert.PublicKey) {
 			ca.primaryCertificate = cert
@@ -182,7 +195,7 @@ func (s *FSStore) LoadCA(name string) (*CA, error) {
 	return ca, nil
 }
 
-func loadPrivateKey(privateKeyPath string) (*rsa.PrivateKey, error) {
+func loadPrivateKey(privateKeyPath string) (crypto.Signer, error) {
 	privateKeyBytes, err := os.ReadFile(privateKeyPath)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -198,11 +211,11 @@ func loadPrivateKey(privateKeyPath string) (*rsa.PrivateKey, error) {
 			return nil, fmt.Errorf("unable to parse private key %q: %w", privateKeyPath, err)
 		}
 
-		rsaKey, ok := key.(*rsa.PrivateKey)
+		signer, ok := key.(crypto.Signer)
 		if !ok {
 			return nil, fmt.Errorf("unexpected private key type in %q: %T", privateKeyPath, key)
 		}
-		return rsaKey, nil
+		return signer, nil
 	}
 
 	return nil, nil


### PR DESCRIPTION
RSA-4096 key generation dominates first boot and node replacement (~5-11s per manager across the etcd peer, etcd server, etcd client, and gRPC keypairs). ECDSA P-256 generation is sub-millisecond and supported by every TLS peer involved (etcd, kube-apiserver, etcd-manager gRPC).

Leaf keys are now generated as ECDSA P-256; an existing key of any other type is regenerated on startup, so upgraded clusters converge to ECDSA on each member's first restart. Certificates were already reissued on every restart, so this adds no extra churn, and all verification is CA-chain based, so mixed RSA/ECDSA members interoperate during rolling updates.

CAs are unchanged: kops-provisioned CAs are loaded as before (now via crypto.Signer, so any key type loads), and self-generated CAs remain RSA-4096. Private keys are written with keyutil.MarshalPrivateKeyToPEM, keeping the RSA on-disk format identical (PKCS#1) and writing ECDSA keys as SEC1.

Note: downgrading etcd-manager after a member has restarted on this version fails to load the EC leaf keys; deleting the leaf .key/.crt files restores the old behavior. CA files are unaffected.

/cc @rifelpet 