### PR TITLE
Bump go-runner base image to go1.26.4 to fix stdlib CVEs

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defaultBaseImage: registry.k8s.io/build-image/go-runner:v2.4.0-go1.26.3-bookworm.0
+defaultBaseImage: registry.k8s.io/build-image/go-runner:v2.4.0-go1.26.4-bookworm.0
 # https://pkg.go.dev/cmd/link
 # -s: omit symbol/debug info
 # -w: omit DWARF symbol table


### PR DESCRIPTION
/cc @rifelpet @ameukam 